### PR TITLE
Update to comply with latest registers API specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To retrieve all registers from [register.gov.uk](https://register.register.gov.u
 OpenRegister.registers
 ```
 
-To retrieve all registers from [openregister.org](http://register.openregister.org/records):
+To retrieve all registers from [alpha.openregister.org](http://register.alpha.openregister.org/records):
 
 ```rb
 OpenRegister.registers from_openregister: true
@@ -26,19 +26,14 @@ puts OpenRegister.registers[1].to_yaml
 
 ```yml
 --- !ruby/object:OpenRegister::Register
-serial_number: 9
-_hash: 247cf017d1b91ca8e0cd3abb60712224c6fa2b03
-fields:
-- country
-- name
-- official-name
-- citizen-names
-- start-date
-- end-date
-phase: alpha
+entry_number: '3'
+item_hash: sha-256:610bde42d3ae2ed3dd829263fe461542742a10ca33865d96d31ae043b242c300
+entry_timestamp: '2016-04-20T14:57:35Z'
 register: country
-registry: foreign-commonwealth-office
 text: British English-language names and descriptive terms for countries
+registry: foreign-commonwealth-office
+phase: beta
+fields: country;name;official-name;citizen-names;start-date;end-date
 ```
 
 ### Retrieve a specific register's records
@@ -58,12 +53,13 @@ puts records.first.to_yaml
 
 ```yml
 --- !ruby/object:OpenRegister::Country
-serial_number: 201
-_hash: b24b537412095cd50fadce010fdeefeb5d3a4b71
-citizen_names: Gambian
-country: GM
-name: Gambia,The
-official_name: The Islamic Republic of The Gambia
+entry_number: '204'
+item_hash: sha-256:466d194d5100532edd115e3f0035967b09bc7b7f5fc444166df6f4a5f7cb9127
+entry_timestamp: '2016-04-05T13:23:05Z'
+country: VA
+name: Vatican City
+official_name: Vatican City State
+citizen_names: Vatican citizen
 ```
 
 ### Retrieve records linked from a specific record
@@ -77,16 +73,17 @@ rating = register.records.first
 
 ```yml
 --- !ruby/object:OpenRegister::FoodPremisesRating
-serial_number: 512920
-_hash: cf0caf7777c57ddc4c7dec859f186ac34b4b6733
-food_premises: '759332'
+entry_number: '512920'
+item_hash: sha-256:59113a9ba41c0c0f019f70003b96d76cb7795a34a1e16514d0cd4c9e42079fda
+entry_timestamp: '2016-03-22T10:50:30Z'
 food_premises_rating: 7593322014-04-09
-food_premises_rating_confidence_in_management_score: '5'
+food_premises: '759332'
+food_premises_rating_value: '4'
 food_premises_rating_hygiene_score: '5'
 food_premises_rating_structural_score: '10'
-food_premises_rating_value: '4'
-inspector: local-authority:506
+food_premises_rating_confidence_in_management_score: '5'
 start_date: '2014-04-09'
+inspector: local-authority:506
 from_openregister: true
 ```
 
@@ -103,8 +100,9 @@ rating._inspector
 
 ```yml
 --- !ruby/object:OpenRegister::LocalAuthority
-serial_number: 408
-_hash: e124e235606b8de334803031567fe4d8e5903ffa
+entry_number: '407'
+item_hash: sha-256:efb42866fdd5abdc3039d9b90544c352489297a66f70e76761c79f65bd29ed8f
+entry_timestamp: '2016-03-31T12:21:09Z'
 local_authority: '506'
 name: Camden
 website: https://www.camden.gov.uk
@@ -119,13 +117,13 @@ rating._food_premises
 
 ```yml
 --- !ruby/object:OpenRegister::FoodPremises
-serial_number: 11
-_hash: 831dab74ad10d89d4d23e167e42a9691a0e77fca
-business: company:07228130
+entry_number: '11'
+item_hash: sha-256:cdb325272d9f0d658616f9c36e3de595fc2b5ce51091696283cf2ca1d3d5741f
+entry_timestamp: '2016-03-22T10:43:15Z'
 food_premises: '759332'
-food_premises_types: []
-local_authority: '506'
 name: Byron
+business: company:07228130
+local_authority: '506'
 premises: '15662079000'
 from_openregister: true
 ```
@@ -138,12 +136,13 @@ rating._food_premises._business
 
 ```yml
 --- !ruby/object:OpenRegister::Company
-serial_number: 4
-_hash: e6b3efd149ae1945f0b6228db7f89eba1f14dd9b
+entry_number: '2'
+item_hash: sha-256:454a74d390dcaa13d999a756b0eb933b81e03c909099e4bb26b1faffc26b5a93
+entry_timestamp: '2016-03-31T12:15:49Z'
 company: 07228130
-industry: '56101'
 name: BYRON HAMBURGERS LIMITED
 registered_office: '10033530330'
+industry: '56101'
 start_date: '2010-04-20'
 from_openregister: true
 ```
@@ -156,8 +155,9 @@ rating._food_premises._business._industry
 
 ```yml
 --- !ruby/object:OpenRegister::Industry
-serial_number: 546
-_hash: 0fbe953759c82b8b9309ba9f4a89277b716ee872
+entry_number: '1352'
+item_hash: sha-256:285a2fbb621fd898ecaa76bab487c2ec103887a4130500be296d5dca5248e46b
+entry_timestamp: '2016-03-31T13:44:24Z'
 industry: '56101'
 name: 'Licensed restaurants '
 from_openregister: true

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -133,7 +133,7 @@ class OpenRegister::MorphListener
   def call klass, symbol
     return if @handling && @handling == [klass, symbol]
     @handling = [klass, symbol]
-    if !register_or_field_class?(klass, symbol) && !hash_or_serial_or_entry?(symbol) && !augmented_field?(symbol)
+    if !register_or_field_class?(klass, symbol) && !is_entry_resource_field?(symbol) && !augmented_field?(symbol)
       add_method_to_access_field_record klass, symbol
     end
   end
@@ -144,7 +144,7 @@ class OpenRegister::MorphListener
     klass.name == 'OpenRegister::Field' || (klass.name == 'OpenRegister::Register' && symbol != :fields)
   end
 
-  def hash_or_serial_or_entry? symbol
+  def is_entry_resource_field? symbol
     [:entry_number, :entry_timestamp, :item_hash].include? symbol
   end
 

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -145,7 +145,7 @@ class OpenRegister::MorphListener
   end
 
   def hash_or_serial_or_entry? symbol
-    [:_hash, :serial_number, :entry].include? symbol
+    [:entry_number, :entry_timestamp, :item_hash].include? symbol
   end
 
   def augmented_field? symbol

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -37,7 +37,7 @@ module OpenRegister
     end
 
     def record register, record, from_openregister: false
-      url = url_for "#{register}/#{record}", register, from_openregister
+      url = url_for "record/#{record}", register, from_openregister
       retrieve(url, register, from_openregister).first
     end
 

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -85,7 +85,7 @@ module OpenRegister
 
     def url_for path, register, from_openregister
       if from_openregister
-        "http://#{register}.openregister.org/#{path}"
+        "http://#{register}.alpha.openregister.org/#{path}"
       else
         "https://#{register}.register.gov.uk/#{path}"
       end

--- a/spec/fixtures/tsv/company-07228130.tsv
+++ b/spec/fixtures/tsv/company-07228130.tsv
@@ -1,2 +1,2 @@
-entry	company	company-status	end-date	industry	name	registered-office	start-date
-4	07228130			56101	BYRON HAMBURGERS LIMITED	10033530330	2010-04-20
+entry-number	item-hash	entry-timestamp	company	name	company-status	registered-office	industry	start-date	end-date
+2	sha-256:454a74d390dcaa13d999a756b0eb933b81e03c909099e4bb26b1faffc26b5a93	2016-03-31T12:15:49Z	07228130	BYRON HAMBURGERS LIMITED		10033530330	56101	2010-04-20

--- a/spec/fixtures/tsv/country-records-1.tsv
+++ b/spec/fixtures/tsv/country-records-1.tsv
@@ -1,2 +1,2 @@
-entry	citizen-names	country	end-date	name	official-name	start-date
-201	Gambian	GM		Gambia,The	The Islamic Republic of The Gambia
+entry-number	item-hash	entry-timestamp	country	name	official-name	citizen-names	start-date	end-date
+202	sha-256:dac66e05ee41707ff9115ed72705eaf8c2e0171285405bea9d859903e8f7ee40	2016-04-05T13:23:05Z	GM	The Gambia	The Islamic Republic of The Gambia	Gambian

--- a/spec/fixtures/tsv/country-records-2.tsv
+++ b/spec/fixtures/tsv/country-records-2.tsv
@@ -1,2 +1,2 @@
-entry	citizen-names	country	end-date	name	official-name	start-date
-1	Soviet citizen	SU	1991-12-25	USSR	Union of Soviet Socialist Republics
+entry-number	item-hash	entry-timestamp	country	name	official-name	citizen-names	start-date	end-date
+1	sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a	2016-04-05T13:23:05Z	SU	USSR	Union of Soviet Socialist Republics	Soviet citizen		1991-12-25

--- a/spec/fixtures/tsv/food-premises-759332.tsv
+++ b/spec/fixtures/tsv/food-premises-759332.tsv
@@ -1,2 +1,2 @@
-entry	business	end-date	food-premises	food-premises-types	local-authority	name	premises	start-date
-11	company:07228130		759332		506	Byron	15662079000
+entry-number	item-hash	entry-timestamp	food-premises	name	business	food-premises-types	local-authority	premises	start-date	end-date
+11	sha-256:cdb325272d9f0d658616f9c36e3de595fc2b5ce51091696283cf2ca1d3d5741f	2016-03-22T10:43:15Z	759332	Byron	company:07228130		506	15662079000

--- a/spec/fixtures/tsv/food-premises-rating-records.tsv
+++ b/spec/fixtures/tsv/food-premises-rating-records.tsv
@@ -1,3 +1,3 @@
-entry	end-date	food-premises	food-premises-rating	food-premises-rating-confidence-in-management-score	food-premises-rating-hygiene-score	food-premises-rating-reply	food-premises-rating-structural-score	food-premises-rating-value	inspector	local-authority	start-date
-512920		759332	7593322014-04-09	5	5		10	4	local-authority:506		2014-04-09
-512919		250023	2500232015-02-02	10	15		10	2	local-authority:900		2015-02-02
+entry-number	item-hash	entry-timestamp	food-premises-rating	food-premises	food-premises-rating-value	food-premises-rating-hygiene-score	food-premises-rating-structural-score	food-premises-rating-confidence-in-management-score	local-authority	food-premises-rating-reply	start-date	inspector	end-date
+512920	sha-256:59113a9ba41c0c0f019f70003b96d76cb7795a34a1e16514d0cd4c9e42079fda	2016-03-22T10:50:30Z	7593322014-04-09	759332	4	5	10	5			2014-04-09	local-authority:506
+512919	sha-256:a29359e4bcc7f298a47f3013905dc3f768acc17201536a4c07e0dd3550bae768	2016-03-22T10:50:30Z	2500232015-02-02	250023	2	15	10	10			2015-02-02	local-authority:900

--- a/spec/fixtures/tsv/food-premises.tsv
+++ b/spec/fixtures/tsv/food-premises.tsv
@@ -1,2 +1,2 @@
-entry	cardinality	datatype	field	phase	register	text
-24	1	string	food-premises	alpha	food-premises	A premises which serves or processes food.
+entry-number	item-hash	entry-timestamp	field	datatype	phase	register	cardinality	text
+352	sha-256:9d844a608467ed2602909c63c37ee315280081945c7814ddf944bfe8a3b96bdc	2016-04-12T15:11:52Z	food-premises	string	alpha	food-premises	1	A premises which serves or processes food.

--- a/spec/fixtures/tsv/premises-15662079000.tsv
+++ b/spec/fixtures/tsv/premises-15662079000.tsv
@@ -1,2 +1,2 @@
-entry	address	end-date	premises	start-date
-1	5167078		15662079000
+entry-number	item-hash	entry-timestamp	premises	address	start-date	end-date
+1	sha-256:a8592404cad14262b387436dd360d4f81fa1659c8bae635d3dc69bda02a8e38f	2016-03-22T10:43:18Z	15662079000	5167078

--- a/spec/fixtures/tsv/register-records.tsv
+++ b/spec/fixtures/tsv/register-records.tsv
@@ -1,7 +1,7 @@
-entry	copyright	fields	phase	register	registry	text
-10		field;datatype;phase;register;cardinality;text	alpha	field	cabinet-office	Field names which may appear in a register
-9		country;name;official-name;citizen-names;start-date;end-date	alpha	country	foreign-commonwealth-office	British English-language names and descriptive terms for countries
-8		public-body;name;website;public-body-type;parent-bodies;text;crest;official-colour	alpha	public-body	cabinet-office	Ministerial Departments and agencies sponsored by HM Government
-7		register;text;registry;phase;copyright;fields	alpha	register	cabinet-office	Registers maintained by HM Government
-6		datatype;phase;text	alpha	datatype	cabinet-office	Datatypes constraining values used by register fields and idenitifying ways in which it may be encoded a representation
-5		food-premises-rating;food-premises;food-premises-rating-value;food-premises-rating-hygiene-score;food-premises-rating-structural-score;food-premises-rating-confidence-in-management-score;local-authority;food-premises-rating-reply;start-date;inspector;end-date	alpha	food-premises-rating	food-standards-agency	Food hygiene inspection ratings
+entry-number	item-hash	entry-timestamp	register	text	registry	phase	copyright	fields
+4	sha-256:ebb8bc0c3639577c5b7d01e5b5a382c52dfc7dee41c290bd8b29647db00259d4	2016-04-20T14:57:35Z	field	Field names which may appear in a register	cabinet-office	beta		field;datatype;phase;register;cardinality;text
+3	sha-256:610bde42d3ae2ed3dd829263fe461542742a10ca33865d96d31ae043b242c300	2016-04-20T14:57:35Z	country	British English-language names and descriptive terms for countries	foreign-commonwealth-office	beta		country;name;official-name;citizen-names;start-date;end-date
+2	sha-256:5fa9c4b569a71542c9c791203d54b6b94c125f189a9c529c63466a0b34cbe38c	2016-04-20T14:57:35Z	register	Registers maintained by HM Government	cabinet-office	beta		register;text;registry;phase;copyright;fields
+1	sha-256:85131084c2175bcea8d1113368b2783a32ee106d9150aed9881b7fa806e3ec47	2016-04-20T14:57:35Z	datatype	Datatypes constraining values used by register fields and idenitifying ways in which it may be encoded a representation	cabinet-office	beta		datatype;phase;text
+95	sha-256:af73462e95fbcc4da50e81e0f1f1006e0c52d433728eff0a406bfc7e53ad5358	2016-04-12T15:12:46Z	public-body	Ministerial Departments and agencies sponsored by HM Government	cabinet-office	alpha		public-body;name;website;public-body-type;parent-bodies;text;crest;official-colour
+96	sha-256:75eb4b008d76bbc3ca0fe6521af31cf98a78e87880c19d2cb759db9be9ad9b20	2016-04-12T15:12:46Z	food-premises-rating	Food hygiene inspection ratings	food-standards-agency	alpha		food-premises-rating;food-premises;food-premises-rating-value;food-premises-rating-hygiene-score;food-premises-rating-structural-score;food-premises-rating-confidence-in-management-score;local-authority;food-premises-rating-reply;start-date;inspector;end-date

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe OpenRegister do
     subject { OpenRegister.registers[1] }
 
     include_examples 'has attributes', {
-      entry: '9',
+      entry_number: '3',
       fields: ['country', 'name', 'official-name', 'citizen-names', 'start-date', 'end-date'],
-      phase: 'alpha',
+      phase: 'beta',
       register: 'country',
       registry: 'foreign-commonwealth-office',
       text: 'British English-language names and descriptive terms for countries'
@@ -119,10 +119,12 @@ RSpec.describe OpenRegister do
 
   shared_examples 'has record attributes' do
     include_examples 'has attributes', {
-      entry: '201',
+      entry_number: '202',
       citizen_names: 'Gambian',
       country: 'GM',
-      name: 'Gambia,The',
+      name: 'The Gambia',
+      official_name: 'The Islamic Republic of The Gambia',
+      entry_timestamp: '2016-04-05T13:23:05Z',
       official_name: 'The Islamic Republic of The Gambia'
     }
   end
@@ -168,7 +170,7 @@ RSpec.describe OpenRegister do
 
   shared_examples 'has field attributes' do
     include_examples 'has attributes', {
-      entry: '24',
+      entry_number: '352',
       cardinality: '1',
       datatype: 'string',
       field: 'food-premises',

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -40,16 +40,16 @@ RSpec.describe OpenRegister do
     stub_tsv_request('http://food-premises-rating.openregister.org/records.tsv',
       './spec/fixtures/tsv/food-premises-rating-records.tsv')
 
-    stub_tsv_request('http://field.openregister.org/field/food-premises.tsv',
+    stub_tsv_request('http://field.openregister.org/record/food-premises.tsv',
       './spec/fixtures/tsv/food-premises.tsv')
 
-    stub_tsv_request('http://food-premises.openregister.org/food-premises/759332.tsv',
+    stub_tsv_request('http://food-premises.openregister.org/record/759332.tsv',
       './spec/fixtures/tsv/food-premises-759332.tsv')
 
-    stub_tsv_request('http://company.openregister.org/company/07228130.tsv',
+    stub_tsv_request('http://company.openregister.org/record/07228130.tsv',
       './spec/fixtures/tsv/company-07228130.tsv')
 
-    stub_tsv_request('http://premises.openregister.org/premises/15662079000.tsv',
+    stub_tsv_request('http://premises.openregister.org/record/15662079000.tsv',
       './spec/fixtures/tsv/premises-15662079000.tsv')
   end
 

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe OpenRegister do
 
     [
       'https://register.register.gov.uk/records.tsv',
-      'http://register.openregister.org/records.tsv'
+      'http://register.alpha.openregister.org/records.tsv'
     ].each do |url|
       stub_tsv_request(url, './spec/fixtures/tsv/register-records.tsv')
     end
 
     [
       'https://country.register.gov.uk/records.tsv',
-      'http://country.openregister.org/records.tsv'
+      'http://country.alpha.openregister.org/records.tsv'
     ].each do |url|
       stub_tsv_request(url, './spec/fixtures/tsv/country-records-1.tsv',
         headers: { 'Link': '<?page-index=2&page-size=100>; rel="next"' })
@@ -31,25 +31,25 @@ RSpec.describe OpenRegister do
 
     [
       'https://country.register.gov.uk/records.tsv?page-index=2&page-size=100',
-      'http://country.openregister.org/records.tsv?page-index=2&page-size=100'
+      'http://country.alpha.openregister.org/records.tsv?page-index=2&page-size=100'
     ].each do |url|
       stub_tsv_request(url, './spec/fixtures/tsv/country-records-2.tsv',
         headers: { 'Link': '<?page-index=1&page-size=100>; rel="previous"' })
     end
 
-    stub_tsv_request('http://food-premises-rating.openregister.org/records.tsv',
+    stub_tsv_request('http://food-premises-rating.alpha.openregister.org/records.tsv',
       './spec/fixtures/tsv/food-premises-rating-records.tsv')
 
-    stub_tsv_request('http://field.openregister.org/record/food-premises.tsv',
+    stub_tsv_request('http://field.alpha.openregister.org/record/food-premises.tsv',
       './spec/fixtures/tsv/food-premises.tsv')
 
-    stub_tsv_request('http://food-premises.openregister.org/record/759332.tsv',
+    stub_tsv_request('http://food-premises.alpha.openregister.org/record/759332.tsv',
       './spec/fixtures/tsv/food-premises-759332.tsv')
 
-    stub_tsv_request('http://company.openregister.org/record/07228130.tsv',
+    stub_tsv_request('http://company.alpha.openregister.org/record/07228130.tsv',
       './spec/fixtures/tsv/company-07228130.tsv')
 
-    stub_tsv_request('http://premises.openregister.org/record/15662079000.tsv',
+    stub_tsv_request('http://premises.alpha.openregister.org/record/15662079000.tsv',
       './spec/fixtures/tsv/premises-15662079000.tsv')
   end
 
@@ -68,7 +68,7 @@ RSpec.describe OpenRegister do
 
   describe 'retrieve registers index from openregister.org' do
     it 'calls correct url' do
-      expect(OpenRegister).to receive(:retrieve).with('http://register.openregister.org/records', :register, true, true, 100)
+      expect(OpenRegister).to receive(:retrieve).with('http://register.alpha.openregister.org/records', :register, true, true, 100)
       OpenRegister.registers from_openregister: true
     end
 


### PR DESCRIPTION
Update to comply with latest registers API specification:
- Change record resource url path to match latest specification
- Update openregister domain to new alpha domain
- Update for specification changes to entry resource numbering and hash