### PR TITLE
Convert cardinality 'n' data from string into array

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard :rspec, cmd: "bundle exec rspec" do
+guard :rspec, cmd: "bundle exec rspec --fail-fast" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ register: country
 text: British English-language names and descriptive terms for countries
 registry: foreign-commonwealth-office
 phase: beta
-fields: country;name;official-name;citizen-names;start-date;end-date
+fields:
+- country
+- name
+- official-name
+- citizen-names
+- start-date
+- end-date
 ```
 
 ### Retrieve a specific register's records

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To retrieve all records from a specific register:
 
 ```rb
 register = OpenRegister.registers[1]
-records = register.records
+records = register._records
 ```
 
 Each record is a Ruby object with a class name derived from the register name:
@@ -68,7 +68,7 @@ Retrieve a food premises rating:
 
 ```rb
 register = OpenRegister.register 'food-premises-rating', from_openregister: true
-rating = register.records.first
+rating = register._records.first
 ```
 
 ```yml
@@ -84,7 +84,7 @@ food_premises_rating_structural_score: '10'
 food_premises_rating_confidence_in_management_score: '5'
 start_date: '2014-04-09'
 inspector: local-authority:506
-from_openregister: true
+_from_openregister: true
 ```
 
 The record objects have methods prefixed with '_'
@@ -106,7 +106,7 @@ entry_timestamp: '2016-03-31T12:21:09Z'
 local_authority: '506'
 name: Camden
 website: https://www.camden.gov.uk
-from_openregister: true
+_from_openregister: true
 ```
 
 Retrieve the food premises from the rating:
@@ -125,7 +125,7 @@ name: Byron
 business: company:07228130
 local_authority: '506'
 premises: '15662079000'
-from_openregister: true
+_from_openregister: true
 ```
 
 Retrieve the business from the food premises:
@@ -144,7 +144,7 @@ name: BYRON HAMBURGERS LIMITED
 registered_office: '10033530330'
 industry: '56101'
 start_date: '2010-04-20'
-from_openregister: true
+_from_openregister: true
 ```
 
 Retrieve the industry from the business:
@@ -160,5 +160,5 @@ item_hash: sha-256:285a2fbb621fd898ecaa76bab487c2ec103887a4130500be296d5dca5248e
 entry_timestamp: '2016-03-31T13:44:24Z'
 industry: '56101'
 name: 'Licensed restaurants '
-from_openregister: true
+_from_openregister: true
 ```

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -60,7 +60,9 @@ module OpenRegister
     end
 
     def field record, from_openregister: false
-      record('field', record, from_openregister: from_openregister)
+      @fields ||= {}
+      key = "#{record}-#{from_openregister}"
+      @fields[key] ||= record('field', record, from_openregister: from_openregister)
     end
 
     private

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -223,7 +223,7 @@ end"
     curie = send(:#{symbol}).split(':')
     register = curie.first
     field = curie.last
-    #{instance_variable} = OpenRegister.record(register, field, from_openregister: #{@from_openregister} )
+    #{instance_variable} = OpenRegister.record(register, field, from_openregister: _from_openregister)
   end
   #{instance_variable}
 end"
@@ -233,7 +233,7 @@ end"
     method = "_#{symbol}"
     instance_variable = "@#{method}"
     "def #{method}
-  #{instance_variable} ||= OpenRegister.record('#{register}', send(:#{symbol}), from_openregister: #{@from_openregister} )
+  #{instance_variable} ||= OpenRegister.record('#{register}', send(:#{symbol}), from_openregister: _from_openregister)
 end"
   end
 

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -20,6 +20,24 @@ class OpenRegister::Field
   include Morph
 end
 
+module OpenRegister::Helpers
+  def is_entry_resource_field? symbol
+    [:entry_number, :entry_timestamp, :item_hash].include? symbol
+  end
+
+  def augmented_field? symbol
+    symbol[/^_/]
+  end
+
+  def cardinality_n? field
+    field.cardinality == 'n' if field && field.cardinality
+  end
+
+  def field_name symbol
+    symbol.to_s.gsub('_','-')
+  end
+end
+
 module OpenRegister
   class << self
 
@@ -140,20 +158,10 @@ class OpenRegister::MorphListener
 
   private
 
+  include OpenRegister::Helpers
+
   def register_or_field_class? klass, symbol
     klass.name == 'OpenRegister::Field' || (klass.name == 'OpenRegister::Register' && symbol != :fields)
-  end
-
-  def is_entry_resource_field? symbol
-    [:entry_number, :entry_timestamp, :item_hash].include? symbol
-  end
-
-  def augmented_field? symbol
-    symbol.to_s[/^_/]
-  end
-
-  def field_name symbol
-    symbol.to_s.gsub('_','-')
   end
 
   def field symbol
@@ -178,10 +186,6 @@ class OpenRegister::MorphListener
                n_split_method(symbol)
              end
     klass.class_eval method if method
-  end
-
-  def cardinality_n? field
-    field.cardinality == 'n' if field && field.cardinality
   end
 
   def n_split_method symbol

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -7,12 +7,12 @@ end
 
 class OpenRegister::Register
   include Morph
-  def all_records page_size: 100
-    OpenRegister::records_for register.to_sym, from_openregister: try(:from_openregister), all: true, page_size: page_size
+  def _all_records page_size: 100
+    OpenRegister::records_for register.to_sym, from_openregister: try(:_from_openregister), all: true, page_size: page_size
   end
 
-  def records
-    OpenRegister::records_for register.to_sym, from_openregister: try(:from_openregister)
+  def _records
+    OpenRegister::records_for register.to_sym, from_openregister: try(:_from_openregister)
   end
 end
 
@@ -99,7 +99,7 @@ module OpenRegister
         end
         results
       end
-      list.each { |item| item.from_openregister = true } if from_openregister
+      list.each { |item| item._from_openregister = true } if from_openregister
       list
     end
 

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -217,21 +217,23 @@ end"
 
   def curie_retrieve_method symbol
     method = "_#{symbol}"
+    instance_variable = "@#{method}"
     "def #{method}
-  unless @#{method}
+  unless #{instance_variable}
     curie = send(:#{symbol}).split(':')
     register = curie.first
     field = curie.last
-    @#{method} = OpenRegister.record(register, field, from_openregister: #{@from_openregister} )
+    #{instance_variable} = OpenRegister.record(register, field, from_openregister: #{@from_openregister} )
   end
-  @#{method}
+  #{instance_variable}
 end"
   end
 
   def retrieve_method symbol, register
     method = "_#{symbol}"
+    instance_variable = "@#{method}"
     "def #{method}
-  @#{method} ||= OpenRegister.record('#{register}', send(:#{symbol}), from_openregister: #{@from_openregister} )
+  #{instance_variable} ||= OpenRegister.record('#{register}', send(:#{symbol}), from_openregister: #{@from_openregister} )
 end"
   end
 

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -89,6 +89,11 @@ RSpec.describe OpenRegister do
   describe 'retrieved record' do
     subject { OpenRegister.registers[1] }
 
+    it 'has fields converted to array', focus: true do
+      fields = subject.instance_variable_get('@fields')
+      expect(fields).to eql(['country', 'name', 'official-name', 'citizen-names', 'start-date', 'end-date'])
+    end
+
     include_examples 'has attributes', {
       entry_number: '3',
       fields: ['country', 'name', 'official-name', 'citizen-names', 'start-date', 'end-date'],

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -125,7 +125,6 @@ RSpec.describe OpenRegister do
       name: 'The Gambia',
       official_name: 'The Islamic Republic of The Gambia',
       entry_timestamp: '2016-04-05T13:23:05Z',
-      official_name: 'The Islamic Republic of The Gambia'
     }
   end
 

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe OpenRegister do
       records = OpenRegister.registers from_openregister: true
       expect(records).to be_an(Array)
       records.each { |r| expect(r).to be_an('OpenRegister::Register'.constantize) }
-      records.each { |r| expect(r.from_openregister).to be(true) }
+      records.each { |r| expect(r._from_openregister).to be(true) }
     end
   end
 
@@ -101,7 +101,7 @@ RSpec.describe OpenRegister do
 
   describe 'retrieve all a register\'s records handling pagination' do
     it 'returns records as Ruby objects' do
-      records = OpenRegister.registers[1].all_records
+      records = OpenRegister.registers[1]._all_records
       expect(records).to be_an(Array)
       records.each { |r| expect(r).to be_an(OpenRegister::Country) }
       expect(records.size).to eq(2)
@@ -110,7 +110,7 @@ RSpec.describe OpenRegister do
 
   describe 'retrieve a register\'s records first page only' do
     it 'returns records as Ruby objects' do
-      records = OpenRegister.registers[1].records
+      records = OpenRegister.registers[1]._records
       expect(records).to be_an(Array)
       records.each { |r| expect(r).to be_an(OpenRegister::Country) }
       expect(records.size).to eq(1)
@@ -129,16 +129,16 @@ RSpec.describe OpenRegister do
   end
 
   describe 'retrieved register record' do
-    subject { OpenRegister.registers[1].all_records[0] }
+    subject { OpenRegister.registers[1]._all_records[0] }
 
     include_examples 'has record attributes'
   end
 
   describe 'retrieved register record from openregister.org' do
-    subject { OpenRegister.registers(from_openregister: true)[1].all_records[0] }
+    subject { OpenRegister.registers(from_openregister: true)[1]._all_records[0] }
 
     include_examples 'has record attributes'
-    include_examples 'has attributes', { from_openregister: true }
+    include_examples 'has attributes', { _from_openregister: true }
   end
 
   describe 'retrieve register by name' do
@@ -160,7 +160,7 @@ RSpec.describe OpenRegister do
         and_return double(register: 'premises', datatype: 'string', cardinality: '1')
 
       register = OpenRegister.register('food-premises-rating', from_openregister: true)
-      record = register.records.first
+      record = register._records.first
       expect(record._food_premises._business.class.name).to eq('OpenRegister::Company')
       expect(record._food_premises._premises.class.name).to eq('OpenRegister::Premises')
       expect(record._food_premises.class.name).to eq('OpenRegister::FoodPremises')


### PR DESCRIPTION
On objects convert the value of any cardinality 'n' fields from being a semicolon separated string into an array.

Keep cache of field records in a hash to avoid having to retrieve a field via the API each time we need to check whether field is cardinality 'n'.

Prefix explicitly added methods not generated from data with an underscore prefix. So these method names are now: `_all_records`, `_records`, `_from_openregister`.