### PR TITLE
Add method to Register to retrieve its field records

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fields:
 
 ### Retrieve a specific register's records
 
-To retrieve all records from a specific register:
+To retrieve first page of records from a specific register:
 
 ```rb
 register = OpenRegister.registers[1]
@@ -82,6 +82,34 @@ country: VA
 name: Vatican City
 official_name: Vatican City State
 citizen_names: Vatican citizen
+```
+
+### Retrieve field definitions for a specific register
+
+To retrieve all field details for a specific register:
+
+```rb
+register = OpenRegister.register 'country'
+fields = register._fields
+```
+
+Each field is returned as a Ruby object:
+
+```rb
+puts fields.first.to_yaml
+```
+
+```yml
+--- !ruby/object:OpenRegister::Field
+entry_number: '8'
+item_hash: sha-256:5a110f91639ee80def2a3bc5293d1130599ca82547402cfd6786a425ffe9b419
+entry_timestamp: '2016-04-20T14:57:11Z'
+field: country
+datatype: string
+phase: beta
+register: country
+cardinality: '1'
+text: ISO 3166-2 two letter code for a country.
 ```
 
 ### Retrieve records linked from a specific record

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -14,6 +14,12 @@ class OpenRegister::Register
   def _records
     OpenRegister::records_for register.to_sym, from_openregister: try(:_from_openregister)
   end
+
+  def _fields
+    fields.map do |field|
+      OpenRegister.field field.to_sym, from_openregister: try(:_from_openregister)
+    end
+  end
 end
 
 class OpenRegister::Field

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe OpenRegister do
   end
 
   before do
-    allow(OpenRegister).to receive(:field).and_return double(register: '', datatype: 'string', cardinality: '1')
+    allow(OpenRegister).to receive(:field).and_return double("OpenRegister::Field", register: '', datatype: 'string', cardinality: '1')
     allow(OpenRegister).to receive(:field).with('fields', from_openregister: false).
       and_return double(register: '', datatype: 'string', cardinality: 'n')
 
@@ -104,7 +104,7 @@ RSpec.describe OpenRegister do
     }
   end
 
-  describe 'retrieve all a register\'s records handling pagination' do
+  describe 'retrieve all a register\'s records handling pagination via #_all_records' do
     it 'returns records as Ruby objects' do
       records = OpenRegister.registers[1]._all_records
       expect(records).to be_an(Array)
@@ -113,12 +113,25 @@ RSpec.describe OpenRegister do
     end
   end
 
-  describe 'retrieve a register\'s records first page only' do
+  describe 'retrieve a register\'s records first page only via #_records' do
     it 'returns records as Ruby objects' do
       records = OpenRegister.registers[1]._records
       expect(records).to be_an(Array)
       records.each { |r| expect(r).to be_an(OpenRegister::Country) }
       expect(records.size).to eq(1)
+    end
+  end
+
+  describe 'retrieve a register\'s fields via #_fields' do
+    it 'returns fields as Ruby objects' do
+      register = OpenRegister.registers[1]
+      fields = register._fields
+      expect(fields).to be_an(Array)
+      expect(fields.size).to eq(6)
+      fields.each do |r|
+        expect(r).to be_a(RSpec::Mocks::Double)
+        expect(r.instance_variable_get(:@name)).to eq("OpenRegister::Field")
+      end
     end
   end
 


### PR DESCRIPTION
Add `_fields` method to Register class that retrieves field records for a given register instance, to enable inspection of a register's field definitions.