### PR TITLE
Use base_url_or_phase parameter to identify phase/domain of register

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+cache: bundler
+rvm:
+  - 2.3.1
+  - 2.2.5
+script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ require 'openregister'
 OpenRegister.registers
 ```
 
-To retrieve all registers from [alpha.openregister.org](http://register.alpha.openregister.org/records):
+To retrieve all registers for a earlier register phase, pass the phase as a symbol. For example to retrieve all
+registers from [alpha.openregister.org](http://register.alpha.openregister.org/records):
+
+```rb
+OpenRegister.registers :alpha
+```
+
+Or to retrieve all registers from a specific url pass the base_url as a string. For example to retrieve all registers
+from [alpha.openregister.org](http://register.alpha.openregister.org/records), you can also call:
 
 ```rb
 OpenRegister.registers 'http://register.alpha.openregister.org/'
@@ -118,7 +126,7 @@ text: ISO 3166-2 two letter code for a country.
 Retrieve a food premises rating:
 
 ```rb
-register = OpenRegister.register 'food-premises-rating', 'http://register.alpha.openregister.org/'
+register = OpenRegister.register 'food-premises-rating', :alpha
 rating = register._records.first
 ```
 
@@ -135,7 +143,7 @@ food_premises_rating_structural_score: '10'
 food_premises_rating_confidence_in_management_score: '5'
 start_date: '2014-04-09'
 inspector: local-authority:506
-_base_url: http://register.alpha.openregister.org/
+_base_url_or_phase: :alpha
 ```
 
 The record objects have methods prefixed with '_'
@@ -157,7 +165,7 @@ entry_timestamp: '2016-03-31T12:21:09Z'
 local_authority: '506'
 name: Camden
 website: https://www.camden.gov.uk
-_base_url: http://register.alpha.openregister.org/
+_base_url_or_phase: :alpha
 ```
 
 Retrieve the food premises from the rating:
@@ -176,7 +184,7 @@ name: Byron
 business: company:07228130
 local_authority: '506'
 premises: '15662079000'
-_base_url: http://register.alpha.openregister.org/
+_base_url_or_phase: :alpha
 ```
 
 Retrieve the business from the food premises:
@@ -195,7 +203,7 @@ name: BYRON HAMBURGERS LIMITED
 registered_office: '10033530330'
 industry: '56101'
 start_date: '2010-04-20'
-_base_url: http://register.alpha.openregister.org/
+_base_url_or_phase: :alpha
 ```
 
 Retrieve the industry from the business:
@@ -211,5 +219,5 @@ item_hash: sha-256:285a2fbb621fd898ecaa76bab487c2ec103887a4130500be296d5dca5248e
 entry_timestamp: '2016-03-31T13:44:24Z'
 industry: '56101'
 name: 'Licensed restaurants '
-_base_url: http://register.alpha.openregister.org/
+_base_url_or_phase: :alpha
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # openregister-ruby
 A Ruby API to UK government data registers http://www.openregister.org/
 
+[![Build Status](https://travis-ci.org/robmckinnon/openregister-ruby.svg?branch=master)](https://travis-ci.org/robmckinnon/openregister-ruby)
+
 ## Install
 
 In your Gemfile add:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OpenRegister.registers
 To retrieve all registers from [alpha.openregister.org](http://register.alpha.openregister.org/records):
 
 ```rb
-OpenRegister.registers from_openregister: true
+OpenRegister.registers 'http://register.alpha.openregister.org/'
 ```
 
 Each record is a Ruby object:
@@ -118,7 +118,7 @@ text: ISO 3166-2 two letter code for a country.
 Retrieve a food premises rating:
 
 ```rb
-register = OpenRegister.register 'food-premises-rating', from_openregister: true
+register = OpenRegister.register 'food-premises-rating', 'http://register.alpha.openregister.org/'
 rating = register._records.first
 ```
 
@@ -135,7 +135,7 @@ food_premises_rating_structural_score: '10'
 food_premises_rating_confidence_in_management_score: '5'
 start_date: '2014-04-09'
 inspector: local-authority:506
-_from_openregister: true
+_base_url: http://register.alpha.openregister.org/
 ```
 
 The record objects have methods prefixed with '_'
@@ -157,7 +157,7 @@ entry_timestamp: '2016-03-31T12:21:09Z'
 local_authority: '506'
 name: Camden
 website: https://www.camden.gov.uk
-_from_openregister: true
+_base_url: http://register.alpha.openregister.org/
 ```
 
 Retrieve the food premises from the rating:
@@ -176,7 +176,7 @@ name: Byron
 business: company:07228130
 local_authority: '506'
 premises: '15662079000'
-_from_openregister: true
+_base_url: http://register.alpha.openregister.org/
 ```
 
 Retrieve the business from the food premises:
@@ -195,7 +195,7 @@ name: BYRON HAMBURGERS LIMITED
 registered_office: '10033530330'
 industry: '56101'
 start_date: '2010-04-20'
-_from_openregister: true
+_base_url: http://register.alpha.openregister.org/
 ```
 
 Retrieve the industry from the business:
@@ -211,5 +211,5 @@ item_hash: sha-256:285a2fbb621fd898ecaa76bab487c2ec103887a4130500be296d5dca5248e
 entry_timestamp: '2016-03-31T13:44:24Z'
 industry: '56101'
 name: 'Licensed restaurants '
-_from_openregister: true
+_base_url: http://register.alpha.openregister.org/
 ```

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -8,16 +8,16 @@ end
 class OpenRegister::Register
   include Morph
   def _all_records page_size: 100
-    OpenRegister::records_for register.to_sym, from_openregister: try(:_from_openregister), all: true, page_size: page_size
+    OpenRegister::records_for register.to_sym, try(:_base_url), all: true, page_size: page_size
   end
 
   def _records
-    OpenRegister::records_for register.to_sym, from_openregister: try(:_from_openregister)
+    OpenRegister::records_for register.to_sym, try(:_base_url)
   end
 
   def _fields
     fields.map do |field|
-      OpenRegister.field field.to_sym, from_openregister: try(:_from_openregister)
+      OpenRegister.field field.to_sym, try(:_base_url)
     end
   end
 end
@@ -47,60 +47,60 @@ end
 module OpenRegister
   class << self
 
-    def registers from_openregister: false
-      registers = records_for :register, from_openregister: from_openregister, all: true
+    def registers base_url=nil
+      registers = records_for :register, base_url, all: true
       registers.each do |r|
-        r._uri = url_for('', r.register, from_openregister)
+        r._uri = url_for('', r.register, base_url)
       end if registers
       registers
     end
 
-    def register register, from_openregister: false
-      registers(from_openregister: from_openregister).detect{ |r| r.register == register }
+    def register register, base_url=nil
+      registers(base_url).detect{ |r| r.register == register }
     end
 
-    def records_for register, from_openregister: false, all: false, page_size: 100
-      url = url_for('records', register, from_openregister)
-      retrieve url, register, from_openregister, all, page_size
+    def records_for register, base_url=nil, all: false, page_size: 100
+      url = url_for('records', register, base_url)
+      retrieve url, register, base_url, all, page_size
     end
 
-    def record register, record, from_openregister: false
-      url = url_for "record/#{record}", register, from_openregister
-      retrieve(url, register, from_openregister).first
+    def record register, record, base_url=nil
+      url = url_for "record/#{record}", register, base_url
+      retrieve(url, register, base_url).first
     end
 
-    def field record, from_openregister: false
+    def field record, base_url=nil
       @fields ||= {}
-      key = "#{record}-#{from_openregister}"
-      @fields[key] ||= record('field', record, from_openregister: from_openregister)
+      key = "#{record}-#{base_url}"
+      @fields[key] ||= record('field', record, base_url)
     end
 
     private
 
     include OpenRegister::Helpers
 
-    def set_morph_listener from_openregister
+    def set_morph_listener base_url
       @listeners ||= {}
-      @listeners[from_openregister] ||= OpenRegister::MorphListener.new from_openregister
-      Morph.register_listener @listeners[from_openregister]
+      @listeners[base_url] ||= OpenRegister::MorphListener.new base_url
+      Morph.register_listener @listeners[base_url]
       @morph_listener_set = true
     end
 
-    def unset_morph_listener from_openregister
-      Morph.unregister_listener @listeners[from_openregister]
+    def unset_morph_listener base_url
+      Morph.unregister_listener @listeners[base_url]
       @morph_listener_set = false
     end
 
-    def augment_register_fields from_openregister, &block
+    def augment_register_fields base_url, &block
       already_set = (@morph_listener_set || false)
-      set_morph_listener(from_openregister) unless already_set
+      set_morph_listener(base_url) unless already_set
       list = yield
-      unset_morph_listener(from_openregister) unless already_set
+      unset_morph_listener(base_url) unless already_set
       list
     end
 
-    def retrieve url, type, from_openregister, all=false, page_size=100
-      list = augment_register_fields(from_openregister) do
+    def retrieve url, type, base_url, all=false, page_size=100
+      list = augment_register_fields(base_url) do
         url = "#{url}.tsv"
         url = "#{url}?page-index=1&page-size=#{page_size}" if page_size != 100
         results = []
@@ -111,19 +111,19 @@ module OpenRegister
         end
         results
       end
-      list.each { |item| item._from_openregister = true } if from_openregister
+      list.each { |item| item._base_url = base_url } if base_url
       list.each { |item| convert_n_cardinality_data! item }
       list
     end
 
     def convert_n_cardinality_data! item
       return if item.is_a?(OpenRegister::Field)
-      from_openregister = (item.try(:_from_openregister)==true)
+      base_url = item.try(:_base_url)
       attributes = item.class.morph_attributes
       cardinality_n_fields = attributes.select do |symbol|
         !is_entry_resource_field?(symbol) &&
           !augmented_field?(symbol) &&
-          (field = field(field_name(symbol), from_openregister: from_openregister)) &&
+          (field = field(field_name(symbol), base_url)) &&
           cardinality_n?(field)
       end
       cardinality_n_fields.each do |symbol|
@@ -131,9 +131,10 @@ module OpenRegister
       end
     end
 
-    def url_for path, register, from_openregister
-      if from_openregister
-        "http://#{register}.alpha.openregister.org/#{path}"
+    def url_for path, register, base_url
+      if base_url
+        host = base_url.sub('register', register.to_s).chomp('/')
+        "#{host}/#{path}"
       else
         "https://#{register}.register.gov.uk/#{path}"
       end
@@ -174,8 +175,8 @@ end
 
 class OpenRegister::MorphListener
 
-  def initialize from_openregister
-    @from_openregister = from_openregister || false
+  def initialize base_url
+    @base_url = base_url || nil
   end
 
   def call klass, symbol
@@ -195,7 +196,7 @@ class OpenRegister::MorphListener
   end
 
   def field symbol
-    OpenRegister::field field_name(symbol), from_openregister: @from_openregister
+    OpenRegister::field field_name(symbol), @base_url
   end
 
   def datatype_curie? field
@@ -233,7 +234,7 @@ end"
     curie = send(:#{symbol}).split(':')
     register = curie.first
     field = curie.last
-    #{instance_variable} = OpenRegister.record(register, field, from_openregister: _from_openregister)
+    #{instance_variable} = OpenRegister.record(register, field, _base_url)
   end
   #{instance_variable}
 end"
@@ -243,7 +244,7 @@ end"
     method = "_#{symbol}"
     instance_variable = "@#{method}"
     "def #{method}
-  #{instance_variable} ||= OpenRegister.record('#{register}', send(:#{symbol}), from_openregister: _from_openregister)
+  #{instance_variable} ||= OpenRegister.record('#{register}', send(:#{symbol}), _base_url)
 end"
   end
 


### PR DESCRIPTION
Instead of passing boolean to identify which domain to use, use a base_url_or_phase parameter. Allows user to pass in the base domain of the register, or phase as a symbol.

Allows us to retrieve data from the different environments, e.g. alpha, beta, and register.gov.uk.