### PR TITLE
Store retrieved register in instance variable on class

### DIFF
--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -209,6 +209,7 @@ class OpenRegister::MorphListener
     klass.class_eval("def self._register(base_url_or_phase); OpenRegister.register(register, base_url_or_phase); end")
     klass.class_eval("def _register; self.class._register(_base_url_or_phase); end")
     klass.class_eval("def _register_fields; self._register._fields; end")
+    klass.class_eval("def _curie; [self.class.register, send(self.class.register.underscore)].join(':'); end")
   end
 
   def register_or_field_class? klass, symbol

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -206,7 +206,7 @@ class OpenRegister::MorphListener
   def add_register_accessor! klass
     register_name = klass.name.sub('OpenRegister::','').gsub(/([a-z])([A-Z])/, '\1-\2').downcase
     klass.class_eval("def self.register; '#{register_name}'; end")
-    klass.class_eval("def self._register(base_url_or_phase); OpenRegister.register(register, base_url_or_phase); end")
+    klass.class_eval(retrieve_method("self._register(base_url_or_phase)", "OpenRegister.register(register, base_url_or_phase)"))
     klass.class_eval("def _register; self.class._register(_base_url_or_phase); end")
     klass.class_eval("def _register_fields; self._register._fields; end")
     klass.class_eval("def _curie; [self.class.register, send(self.class.register.underscore)].join(':'); end")
@@ -246,7 +246,7 @@ class OpenRegister::MorphListener
   @#{symbol}
 end"]
     if register = register_for_field(field)
-      method = retrieve_method(symbol, "#{symbol}.map {|code| OpenRegister.record('#{field.register}', code, _base_url_or_phase) }")
+      method = retrieve_method("_#{symbol}", "#{symbol}.map {|code| OpenRegister.record('#{field.register}', code, _base_url_or_phase) }")
       methods << method
     end
     methods
@@ -254,17 +254,16 @@ end"]
 
   def curie_retrieve_method symbol
     retrieve = "(parts = send(:#{symbol}).split(':')) && OpenRegister.record(parts.first, parts.last, _base_url_or_phase)"
-    [retrieve_method(symbol, retrieve)]
+    [retrieve_method("_#{symbol}", retrieve)]
   end
 
   def direct_retrieve_method symbol, register
     retrieve = "OpenRegister.record('#{register}', send(:#{symbol}), _base_url_or_phase)"
-    [retrieve_method(symbol, retrieve)]
+    [retrieve_method("_#{symbol}", retrieve)]
   end
 
-  def retrieve_method symbol, retrieve
-    method = "_#{symbol}"
-    instance_variable = "@#{method}"
+  def retrieve_method method, retrieve
+    instance_variable = "@#{method}".gsub('.', '_').split("(").first
     "def #{method}
   #{instance_variable} ||= #{retrieve}
 end"

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -234,7 +234,7 @@ class OpenRegister::MorphListener
              elsif cardinality_n? field
                n_split_methods(symbol, field)
              elsif register = register_for_field(field)
-               retrieve_method(symbol, register)
+               direct_retrieve_method(symbol, register)
              end
     methods.each {|method| klass.class_eval method} if methods
   end
@@ -245,39 +245,28 @@ class OpenRegister::MorphListener
   @#{symbol}
 end"]
     if register = register_for_field(field)
-      method = "_#{symbol}"
-      instance_variable = "@#{method}"
-      methods << "
-def #{method}
-  unless #{instance_variable}
-    #{instance_variable} = #{symbol}.map {|code| OpenRegister.record('#{field.register}', code, _base_url_or_phase) }
-  end
-  #{instance_variable}
-end"
+      method = retrieve_method(symbol, "#{symbol}.map {|code| OpenRegister.record('#{field.register}', code, _base_url_or_phase) }")
+      methods << method
     end
     methods
   end
 
   def curie_retrieve_method symbol
-    method = "_#{symbol}"
-    instance_variable = "@#{method}"
-    ["def #{method}
-  unless #{instance_variable}
-    curie = send(:#{symbol}).split(':')
-    register = curie.first
-    field = curie.last
-    #{instance_variable} = OpenRegister.record(register, field, _base_url_or_phase)
-  end
-  #{instance_variable}
-end"]
+    retrieve = "(parts = send(:#{symbol}).split(':')) && OpenRegister.record(parts.first, parts.last, _base_url_or_phase)"
+    [retrieve_method(symbol, retrieve)]
   end
 
-  def retrieve_method symbol, register
+  def direct_retrieve_method symbol, register
+    retrieve = "OpenRegister.record('#{register}', send(:#{symbol}), _base_url_or_phase)"
+    [retrieve_method(symbol, retrieve)]
+  end
+
+  def retrieve_method symbol, retrieve
     method = "_#{symbol}"
     instance_variable = "@#{method}"
-    ["def #{method}
-  #{instance_variable} ||= OpenRegister.record('#{register}', send(:#{symbol}), _base_url_or_phase)
-end"]
+    "def #{method}
+  #{instance_variable} ||= #{retrieve}
+end"
   end
 
 end

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -308,6 +308,10 @@ RSpec.describe OpenRegister do
       expect(subject._uri).to eq('http://food-premises.alpha.openregister.org/record/759332')
     end
 
+    it 'returns its curie' do
+      expect(subject._curie).to eq('food-premises:759332')
+    end
+
     it 'returns register from class method' do
       expect(subject.class.register).to eq('food-premises')
     end


### PR DESCRIPTION
Store retrieved register in instance variable in order to make multiple requests faster.

Add _curie() method to record that constructs its curie from register name and record id.