### PR TITLE
Update readme example to use correct phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ text: ISO 3166-2 two letter code for a country.
 Retrieve a food premises rating:
 
 ```rb
-register = OpenRegister.register 'food-premises-rating', :alpha
+register = OpenRegister.register 'food-premises-rating', :discovery
 rating = register._records.first
 ```
 
@@ -157,7 +157,7 @@ food_premises_rating_structural_score: '10'
 food_premises_rating_confidence_in_management_score: '5'
 start_date: '2014-04-09'
 inspector: local-authority:506
-_base_url_or_phase: :alpha
+_base_url_or_phase: :discovery
 ```
 
 The record objects have methods prefixed with '_'
@@ -179,7 +179,7 @@ entry_timestamp: '2016-03-31T12:21:09Z'
 local_authority: '506'
 name: Camden
 website: https://www.camden.gov.uk
-_base_url_or_phase: :alpha
+_base_url_or_phase: :discovery
 ```
 
 Retrieve the food premises from the rating:
@@ -198,7 +198,7 @@ name: Byron
 business: company:07228130
 local_authority: '506'
 premises: '15662079000'
-_base_url_or_phase: :alpha
+_base_url_or_phase: :discovery
 ```
 
 Retrieve the business from the food premises:
@@ -217,7 +217,7 @@ name: BYRON HAMBURGERS LIMITED
 registered_office: '10033530330'
 industry: '56101'
 start_date: '2010-04-20'
-_base_url_or_phase: :alpha
+_base_url_or_phase: :discovery
 ```
 
 Retrieve the industry from the business:
@@ -233,5 +233,5 @@ item_hash: sha-256:285a2fbb621fd898ecaa76bab487c2ec103887a4130500be296d5dca5248e
 entry_timestamp: '2016-03-31T13:44:24Z'
 industry: '56101'
 name: 'Licensed restaurants '
-_base_url_or_phase: :alpha
+_base_url_or_phase: :discovery
 ```


### PR DESCRIPTION
The food rating example registers have moved from the alpha to the discovery phase.