### PR TITLE
Update morph dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
+  - 2.4.0
   - 2.3.1
   - 2.2.5
+  - ruby-head
 script: bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,4 @@ group :test do
 end
 
 gem 'morph', '>= 0.5.1'
-gem 'rest-client', '>= 2.0.0'
+gem 'rest-client', '>= 2.0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ group :test do
   gem 'webmock'
 end
 
-gem 'morph', '>= 0.5.0'
+gem 'morph', '>= 0.5.1'
 gem 'rest-client', '>= 2.0.0'


### PR DESCRIPTION
- Require morph gem 0.5.1 or above, removes the Fixnum deprecation warning in Ruby 2.4.
- Include Ruby 2.4 in travis CI config.
- Update version of rest-client dependency.